### PR TITLE
Add formatting directive.

### DIFF
--- a/certstream.go
+++ b/certstream.go
@@ -27,7 +27,7 @@ func CertStreamEventStream(skipHeartbeats bool) chan jsonq.JsonQuery {
 				var v interface{}
 				err = c.ReadJSON(&v)
 				if err != nil {
-					log.Fatalf("Error decoding json frame!", err)
+					log.Fatalf("Error decoding json frame! %v\n", err)
 				}
 
 				log.Info(v)
@@ -36,7 +36,7 @@ func CertStreamEventStream(skipHeartbeats bool) chan jsonq.JsonQuery {
 
 				res, err := jq.String("message_type")
 				if err != nil {
-					log.Fatalf("Error creating jq!", err)
+					log.Fatalf("Error creating jq! %v\n", err)
 				}
 
 				if (skipHeartbeats && res == "heartbeat"){

--- a/example/main.go
+++ b/example/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/op/go-logging"
 	"github.com/CaliDog/certstream-go"
+	logging "github.com/op/go-logging"
 )
 
 var log = logging.MustGetLogger("example")

--- a/example/main.go
+++ b/example/main.go
@@ -15,7 +15,7 @@ func main() {
 		message_type, err := jq.String("message_type")
 
 		if err != nil {
-			log.Fatalf("Error parsing message_type", err)
+			log.Fatalf("Error parsing message_type: %v", err)
 		}
 
 		log.Info("Message type -> ", message_type)


### PR DESCRIPTION
`log.Fatalf()` requires the use of a formatting directive. I've added in the standard `%v` to output the error in-line appropriately.