### PR TITLE
Refactor the library to use channels to send messages instead of logs

### DIFF
--- a/certstream.go
+++ b/certstream.go
@@ -38,7 +38,7 @@ func CertStreamEventStream(skipHeartbeats bool) (chan jsonq.JsonQuery, chan erro
 					errStream <- errors.Wrap(err, "Error creating jq object!")
 				}
 
-				if (skipHeartbeats && res == "heartbeat"){
+				if skipHeartbeats && res == "heartbeat" {
 					continue
 				}
 

--- a/example/main.go
+++ b/example/main.go
@@ -12,13 +12,13 @@ func main() {
 	for {
 		select {
 			case jq := <-stream:
-				message_type, err := jq.String("message_type")
+				messageType, err := jq.String("message_type")
 
 				if err != nil{
 					log.Fatal("Error decoding jq string")
 				}
 
-				log.Info("Message type -> ", message_type)
+				log.Info("Message type -> ", messageType)
 				log.Info("recv: ", jq)
       
 			case err := <-errStream:

--- a/example/main.go
+++ b/example/main.go
@@ -8,18 +8,22 @@ import (
 var log = logging.MustGetLogger("example")
 
 func main() {
-	stream := certstream.CertStreamEventStream(false)
+	stream, errStream := certstream.CertStreamEventStream(false)
+	for {
+		select {
+			case jq := <-stream:
+				message_type, err := jq.String("message_type")
 
-	for jq := range stream {
+				if err != nil{
+					log.Fatal("Error decoding jq string")
+				}
 
-		message_type, err := jq.String("message_type")
+				log.Info("Message type -> ", message_type)
+				log.Info("recv: ", jq)
 
-		if err != nil {
-			log.Fatalf("Error parsing message_type", err)
+			case err := <-errStream:
+				log.Error(err)
+
 		}
-
-		log.Info("Message type -> ", message_type)
-		log.Info("recv: ", jq)
-
 	}
 }


### PR DESCRIPTION
This should be the changes necessary to make certstream operate with 2 channels instead of a single channel and error logging (since error logging isn't the most pragmatic way of dealing with errors in golang). 

This addresses #3 