### PR TITLE
Add heartbeats

### DIFF
--- a/certstream.go
+++ b/certstream.go
@@ -47,6 +47,7 @@ func CertStreamEventStream(skipHeartbeats bool) (chan jsonq.JsonQuery, chan erro
 
 			for {
 				var v interface{}
+				c.SetReadDeadline(time.Now().Add(15 * time.Second))
 				err = c.ReadJSON(&v)
 				if err != nil {
 					errStream <- errors.Wrap(err, "Error decoding json frame!")


### PR DESCRIPTION
Hello!

Related to https://github.com/CaliDog/certstream-go/issues/8

This PR adds heartbeats so that the Certstream server (or rather, Cowboy), won't disconnect the client after some time. I also added a read timeout so that the client can reconnect if the connection breaks. Even with properly configured heartbeats, the public Certstream server seems to be very slow to answer heartbeats, and clients are sometimes disconnected because of that.

I've been using this code with my own Certstream server instance for a few weeks now and all connectivity issues have disappeared.

Does it look good to you?
